### PR TITLE
Update to work with provided headers

### DIFF
--- a/httpio.py
+++ b/httpio.py
@@ -191,10 +191,12 @@ class HTTPIOFile(BufferedIOBase):
 
     def _read_raw(self, start, end):
         headers = {"Range": "bytes=%d-%d" % (start, end - 1)}
+        headers.update(self._kwargs.get("headers", {}))
+        kwargs = dict(self._kwargs)
+        kwargs['headers'] = headers
         response = self._session.get(
             self.url,
-            headers=headers,
-            **self._kwargs)
+            **kwargs)
         response.raise_for_status()
         return response.content
 


### PR DESCRIPTION
Right now if you try to specify headers like
```httpio.open(url, allow_redirects=True, headers={ "Authorization" : "Token mytoken"})```
you will get an error:
```TypeError: get() got multiple values for keyword argument 'headers'```

This patch fixes that error.