### PR TITLE
Add fallback to GET if HEAD doesn't work

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+== 0.4.0 ==
+
+* Added fallback behaviour to try GET for content length when HEAD isn't available
+* Added `no_head_request` option
+* Added `session_args` to pass kwargs to the constructor of `aiohttp.ClientSession`
+* Made unit tests slightly faster when generating data
+
 == 0.3.0 ==
 
 * Addition of asyncio compatible interface for use in python versions 3.6 and above

--- a/httpio_async/__init__.py
+++ b/httpio_async/__init__.py
@@ -32,15 +32,17 @@ class AsyncHTTPIOFile(object):
     """An asynchronous equivalent to httpio.HTTPIOFile.
     Sadly this class cannot descend from that one for technical reasons.
     """
-    def __init__(self, url, block_size=-1, **kwargs):
+    def __init__(self, url, block_size=-1, no_head_request=False, **kwargs):
         """
         :param url: The URL of the file to open
         :param block_size: The cache block size, or `-1` to disable caching.
+        :param no_head_request: Don't make a HEAD request to check the file size, use a GET instead
         :param kwargs: Additional arguments to pass to `session.get`
         """
         super(AsyncHTTPIOFile, self).__init__()
         self.url = url
         self.block_size = block_size
+        self.no_head_request = no_head_request
 
         self._kwargs = kwargs
         self._cursor = 0
@@ -71,10 +73,24 @@ class AsyncHTTPIOFile(object):
 
         if self._session is None:
             self._session = await aiohttp.ClientSession().__aenter__()
-            async with self._session.head(self.url, **self._kwargs) as response:
+
+            if not self.no_head_request:
+                async with self._session.head(self.url, **self._kwargs) as response:
+                    # In some cases, notably including AWS S3 presigned URLs, it's only possible to GET the URL and HEAD
+                    # isn't supported. In these cases we skip raising an exception and fall through to the
+                    # `no_head_request` behaviour instead
+                    if response.status != 405 and response.status != 403:
+                        response.raise_for_status()
+                        self.length = int(response.headers.get('content-length', None))
+                        self.closed = False
+                        return
+
+            async with self._session.get(self.url, **self._kwargs) as response:
                 response.raise_for_status()
                 self.length = int(response.headers.get('content-length', None))
                 self.closed = False
+                # Note that not reading the response body will cause the underlying connection to be closed before the
+                # server sends the file
 
     async def __aenter__(self):
         await self.open()
@@ -291,7 +307,11 @@ class AsyncHTTPIOFileContextManagerMixin (object):
     """This is a mixin for HTTPIOFile to make it act as an async context manager via the AsyncHTTPIOFile class"""
 
     async def __aenter__(self):
-        self.__acontextmanager = AsyncHTTPIOFile(self.url, self.block_size, **self._kwargs)
+        self.__acontextmanager = AsyncHTTPIOFile(self.url,
+                                                 self.block_size,
+                                                 no_head_request=self.no_head_request,
+                                                 **self._kwargs)
+
         return await self.__acontextmanager.__aenter__()
 
     async def __aexit__(self, exc_type, exc, tb):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if version_info[0] > 3 or (version_info[0] == 3 and version_info[1] >= 6):
 
 setup(
     name='httpio',
-    version='0.3.0',
+    version='0.4.0',
     author='Barney Gale',
     author_email='barney@barneygale.co.uk',
     url='https://github.com/barneygale/httpio',

--- a/tests/random_source_data.py
+++ b/tests/random_source_data.py
@@ -1,0 +1,15 @@
+import random
+from six import int2byte
+
+# 8 MB of random data for the HTTP requests to return
+DATA = b''.join(int2byte(random.getrandbits(8))
+                for _ in range(0, 8*1024*1024))
+
+OTHER_DATA = b''.join(int2byte(random.getrandbits(8))
+                      for _ in range(0, 8*1024*1024))
+
+ASCII_LINES = ["Line0\n",
+               "Line the first\n",
+               "Line Returns\n",
+               "Line goes forth"]
+ASCII_DATA = b''.join(line.encode('ascii') for line in ASCII_LINES)

--- a/tests/test_async_httpio.py
+++ b/tests/test_async_httpio.py
@@ -4,31 +4,18 @@ from unittest import TestCase
 from httpio import HTTPIOFile
 
 import mock
-import random
 import re
 import warnings
 
 from io import SEEK_CUR, SEEK_END
+
+from random_source_data import DATA, OTHER_DATA, ASCII_DATA, ASCII_LINES
 
 
 def async_func(f):
     async def __inner(*args, **kwargs):
         return f(*args, **kwargs)
     return __inner
-
-
-# 8 MB of random data for the HTTP requests to return
-DATA = bytes(random.randint(0, 0xFF)
-             for _ in range(0, 8*1024*1024))
-
-OTHER_DATA = bytes(random.randint(0, 0xFF)
-                   for _ in range(0, 8*1024*1024))
-
-ASCII_LINES = ["Line0\n",
-               "Line the first\n",
-               "Line Returns\n",
-               "Line goes forth"]
-ASCII_DATA = b''.join(line.encode('ascii') for line in ASCII_LINES)
 
 
 IOBaseError = OSError

--- a/tests/test_async_httpio.py
+++ b/tests/test_async_httpio.py
@@ -1,9 +1,9 @@
 import asyncio
 from unittest import TestCase
+from unittest import mock
 
 from httpio import HTTPIOFile
 
-import mock
 import re
 import warnings
 

--- a/tests/test_sync_httpio.py
+++ b/tests/test_sync_httpio.py
@@ -38,16 +38,17 @@ class TestHTTPIOFile(TestCase):
 
         self.data_source = DATA
         self.error_code = None
+        self.head_error_code = None
 
         def _head(url, **kwargs):
-            if self.error_code is None:
+            if self.error_code is None and self.head_error_code is None:
                 return mock.MagicMock(status_code=204,
                                       headers={'Content-Length':
                                                len(self.data_source),
                                                'Accept-Ranges':
                                                'bytes'})
             else:
-                return mock.MagicMock(status_code=self.error_code,
+                return mock.MagicMock(status_code=self.head_error_code or self.error_code,
                                       raise_for_status=mock.MagicMock(
                                           side_effect=HTTPException))
 
@@ -64,12 +65,22 @@ class TestHTTPIOFile(TestCase):
                         end = int(m.group(2)) + 1
 
             if self.error_code is not None:
-                return mock.MagicMock(status_code=self.error_code,
-                                      raise_for_status=mock.MagicMock(
-                                          side_effect=HTTPException))
+                response_mock = mock.MagicMock(status_code=self.error_code,
+                                               raise_for_status=mock.MagicMock(side_effect=HTTPException))
+                response_mock.__enter__.return_value = response_mock
+
+                return response_mock
             else:
-                return mock.MagicMock(status_code=200,
-                                      content=self.data_source[start:end])
+                content_length = (end or len(self.data_source)) - (start or 0)
+
+                response_mock = mock.MagicMock(status_code=200,
+                                               headers={
+                                                   'Content-Length': content_length,
+                                                   'Accept-Ranges': 'bytes'},
+                                               content=self.data_source[start:end])
+
+                response_mock.__enter__.return_value = response_mock
+                return response_mock
 
         self.session.get.side_effect = _get
 
@@ -258,6 +269,27 @@ class TestHTTPIOFile(TestCase):
         with HTTPIOFile('http://www.example.com/test/', 1024) as io:
             with self.assertRaises(IOBaseError):
                 io.writelines([line.encode('ascii') for line in ASCII_LINES])
+
+    def test_ignores_head_error_when_no_head_request_set(self):
+        """If the no_head_request flag is set, an error returned by HEAD should be ignored"""
+        self.head_error_code = 404
+        with HTTPIOFile('http://www.example.com/test/', 1024, no_head_request=True):
+            pass
+
+    def test_throws_exception_when_get_returns_error_when_no_head_request_set(self):
+        self.error_code = 404
+        with self.assertRaises(HTTPException):
+            with HTTPIOFile('http://www.example.com/test/', 1024, no_head_request=True):
+                pass
+
+    def test_retries_with_get_when_head_returns_403(self):
+        """Test data can be read when the GET works but the HEAD request returns 403
+
+        This happens when given an S3 pre-signed URL, because they only support one method
+        """
+        self.head_error_code = 403
+        with HTTPIOFile('http://www.example.com/test/', 1024):
+            pass
 
 
 if __name__ == "__main__":

--- a/tests/test_sync_httpio.py
+++ b/tests/test_sync_httpio.py
@@ -9,24 +9,11 @@ from io import BufferedIOBase, UnsupportedOperation
 from io import SEEK_CUR, SEEK_END
 
 import mock
-import random
 import re
 
-from six import int2byte, PY3
+from six import PY3
 
-
-# 8 MB of random data for the HTTP requests to return
-DATA = b''.join(int2byte(random.randint(0, 0xFF))
-                for _ in range(0, 8*1024*1024))
-
-OTHER_DATA = b''.join(int2byte(random.randint(0, 0xFF))
-                      for _ in range(0, 8*1024*1024))
-
-ASCII_LINES = ["Line0\n",
-               "Line the first\n",
-               "Line Returns\n",
-               "Line goes forth"]
-ASCII_DATA = b''.join(line.encode('ascii') for line in ASCII_LINES)
+from random_source_data import DATA, OTHER_DATA, ASCII_DATA, ASCII_LINES
 
 
 # The expected exception from unimplemented IOBase operations


### PR DESCRIPTION
This works around a problems where servers don't support HEAD correctly, such as AWS S3 presigned URLs which incorporate the method into the URL signature, so you can't produce one that supports both GET and HEAD. This PR adds a fallback behaviour in response to `405 Method Not Implemented` or `403 Forbidden` (S3's response) on HEAD to try a GET instead, but avoids reading the response body to prompt the server not to send any more data.

I've also made a tweak to the unit tests in the process to generate data with the slightly faster (but less random) `random.getrandbits` and factor out sample data generation across both tests.

cc @jamesba - would you mind reviewing this too?